### PR TITLE
fix: add xstring dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,8 @@ RUN tlmgr install --repository=${TEXLIVE_MIRROR} \
         upquote \
         xifthen \
         xkeyval \
-        xpatch
+        xpatch  \
+        xstring
 
 RUN fmtutil -sys --all \
     && ln -sf python3 /usr/bin/python


### PR DESCRIPTION
Add missing xstring dependency in order to compile documents.